### PR TITLE
support for reading the internal temperature sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ This fork was created to provide a small and straightforward library for using t
 - Added function to change LDO mode (defaults to 0)
 	- See function `setLDOMode()`, param `NAU7802_LDOMODE_0` or `NAU7802_LDOMODE_1`
 	- See Table 11.14 in datasheet
+- Added functionality to read the NAU7802's internal temperature sensor
+    - See `setChannel()`, param `NAU7802_CHANNEL_TS`
+    - Use the gain factor 1 or 2, see Section 8.9 in datasheet
 - Tweaked default initialization settings
 	- Sampling: 10Hz
 	- PGA Gain: 1x
@@ -39,7 +42,6 @@ This fork was created to provide a small and straightforward library for using t
 
 ### Future Ideas
 - Add functions to toggle the internal weak & strong I2C pullups
-- Add functionality to read the NAU7802's internal temperature sensor
 
 
 SparkFun Attribution

--- a/src/NAU7802_2CH.cpp
+++ b/src/NAU7802_2CH.cpp
@@ -220,13 +220,19 @@ bool NAU7802::setSampleRate(uint8_t rate)
   return (setRegister(NAU7802_CTRL2, value));
 }
 
-//Select between 1 and 2
+//Select between 1 and 3
 bool NAU7802::setChannel(uint8_t channelNumber)
 {
-  if (channelNumber == NAU7802_CHANNEL_1)
-    return (clearBit(NAU7802_CTRL2_CHS, NAU7802_CTRL2)); //Channel 1 (default)
-  else
-    return (setBit(NAU7802_CTRL2_CHS, NAU7802_CTRL2)); //Channel 2
+  switch (channelNumber) {
+    case NAU7802_CHANNEL_1:
+      return (clearBit(NAU7802_I2C_CONTROL_TS, NAU7802_I2C_CONTROL) && clearBit(NAU7802_CTRL2_CHS, NAU7802_CTRL2)); //Channel 1 (default)
+    case NAU7802_CHANNEL_2:
+      return (clearBit(NAU7802_I2C_CONTROL_TS, NAU7802_I2C_CONTROL) && setBit(NAU7802_CTRL2_CHS, NAU7802_CTRL2)); //Channel 2
+    case NAU7802_CHANNEL_TS:
+      return (setBit(NAU7802_I2C_CONTROL_TS, NAU7802_I2C_CONTROL));  //Temperature sensor
+    default:
+      return false;
+  }
 }
 
 //Power up digital and analog sections of scale
@@ -292,7 +298,7 @@ unsigned long NAU7802::getLDORampDelay()
 }
 
 //Set the gain
-//x1, 2, 4, 8, 16, 32, 64, 128 are avaialable
+//x1, 2, 4, 8, 16, 32, 64, 128 are available
 bool NAU7802::setGain(uint8_t gainValue)
 {
   if (gainValue > 0b111)

--- a/src/NAU7802_2CH.cpp
+++ b/src/NAU7802_2CH.cpp
@@ -220,7 +220,7 @@ bool NAU7802::setSampleRate(uint8_t rate)
   return (setRegister(NAU7802_CTRL2, value));
 }
 
-//Select between 1 and 3
+//Select between 0 and 2
 bool NAU7802::setChannel(uint8_t channelNumber)
 {
   switch (channelNumber) {

--- a/src/NAU7802_2CH.h
+++ b/src/NAU7802_2CH.h
@@ -211,7 +211,7 @@ public:
   void setLDORampDelay(unsigned long delay); //LDO (AVDD) takes ~200ms to ramp up. During .begin, delay for _ldoRampDelay before performing calibrateAFE
   unsigned long getLDORampDelay();
   bool setSampleRate(uint8_t rate);       //Set the readings per second. 10, 20, 40, 80, and 320 samples per second is available
-  bool setChannel(uint8_t channelNumber); //Select between 1 and 3
+  bool setChannel(uint8_t channelNumber); //Select between 0 and 2
 
   bool calibrateAFE(NAU7802_Cal_Mode mode = NAU7802_CALMOD_INTERNAL);      //Synchronous calibration of the analog front end of the NAU7802. Returns true if CAL_ERR bit is 0 (no error)
   void beginCalibrateAFE(NAU7802_Cal_Mode mode = NAU7802_CALMOD_INTERNAL); //Begin asynchronous calibration of the analog front end of the NAU7802. Poll for completion with calAFEStatus() or wait with waitForCalibrateAFE().

--- a/src/NAU7802_2CH.h
+++ b/src/NAU7802_2CH.h
@@ -90,6 +90,19 @@ typedef enum
   NAU7802_CTRL2_CHS = 7,
 } CTRL2_Bits;
 
+//Bits within the I2C_CONTROL register
+typedef enum
+{
+  NAU7802_I2C_CONTROL_BGPCP = 0,  // Disables bandgap chopper
+  NAU7802_I2C_CONTROL_TS    = 1,  // Switches PGA input to temperature sensor
+  NAU7802_I2C_CONTROL_BOPGA = 2,  // Enables the 2.5uA burnout current source to the PGA positive input
+  NAU7802_I2C_CONTROL_SI    = 3,  // Short the input together, measure offset
+  NAU7802_I2C_CONTROL_WPD   = 4,  // Disable bit for Weak Pull Up for I2C SCLK and SDA
+  NAU7802_I2C_CONTROL_SPE   = 5,  // Enable bit for Strong Pull Up for I2C SCLK and SDA
+  NAU7802_I2C_CONTROL_FRD   = 6,  // Enable bit for Fast Read ADC DATA (special non-standard I2C)
+  NAU7802_I2C_CONTROL_CRSD  = 7,  // Enable bit for Pull SDA low when conversion complete and I2C IDLE (special non-standard I2C)
+} I2C_CONTROL_Bits;
+
 //Bits within the PGA register
 typedef enum
 {
@@ -159,6 +172,7 @@ typedef enum
 {
   NAU7802_CHANNEL_1 = 0,
   NAU7802_CHANNEL_2 = 1,
+  NAU7802_CHANNEL_TS = 2,
 } NAU7802_Channels;
 
 //Calibration state
@@ -197,7 +211,7 @@ public:
   void setLDORampDelay(unsigned long delay); //LDO (AVDD) takes ~200ms to ramp up. During .begin, delay for _ldoRampDelay before performing calibrateAFE
   unsigned long getLDORampDelay();
   bool setSampleRate(uint8_t rate);       //Set the readings per second. 10, 20, 40, 80, and 320 samples per second is available
-  bool setChannel(uint8_t channelNumber); //Select between 1 and 2
+  bool setChannel(uint8_t channelNumber); //Select between 1 and 3
 
   bool calibrateAFE(NAU7802_Cal_Mode mode = NAU7802_CALMOD_INTERNAL);      //Synchronous calibration of the analog front end of the NAU7802. Returns true if CAL_ERR bit is 0 (no error)
   void beginCalibrateAFE(NAU7802_Cal_Mode mode = NAU7802_CALMOD_INTERNAL); //Begin asynchronous calibration of the analog front end of the NAU7802. Poll for completion with calAFEStatus() or wait with waitForCalibrateAFE().


### PR DESCRIPTION
This pull request adds support for reading the internal temperature sensor.
It does so by setting a bit in the I2C-control-register when selecting the temperature sensor as source channel and clears it when selecting any other channel.